### PR TITLE
Added tmux to stow list, and added missing install scripts to run.sh

### DIFF
--- a/dotfiles-setup.sh
+++ b/dotfiles-setup.sh
@@ -29,6 +29,7 @@ if [ $? -eq 0 ]; then
   stow zshrc
   stow nvim
   stow starship
+  stow tmux
 else
   echo "Failed to clone the repository."
   exit 1

--- a/run.sh
+++ b/run.sh
@@ -124,6 +124,14 @@ else
   # Some programs just run better as flatpaks. Like discord/spotify
   echo "Installing flatpaks (like discord and spotify)"
   . install-flatpaks.sh
+
+  # Install dotfiles
+  echo "Installing dotfiles/configurations..."
+  . dotfiles-setup.sh 
+
+  # Install TPM
+  echo "Installing TPM and TMUX extensions..."
+  . install-tpm.sh
 fi
 
 echo "Setup complete! You may want to reboot your system."


### PR DESCRIPTION
The original dotfiles-setup.sh script didn't adequately stow the tmux configuration, so I added tmux to the list of packages managed with GNU stow. 

run.sh originally didn't call dotfiles-setup.sh or install-tpm.sh, so I added calls to those in run.sh to ensure that it fully installs all configurations. 

There was no open issue relating to these scripts not being utilized in the original run.sh, but since it was a simple fix I decided to just create a PR for them.

These changes are based on changes I made in my personal fork, if there are any issues with them please let me know and I will happily update my PR.